### PR TITLE
Fix invalid entity reference errors in applyMobScaling

### DIFF
--- a/src/main/java/com/azuredoom/levelingcore/utils/MobLevelingUtil.java
+++ b/src/main/java/com/azuredoom/levelingcore/utils/MobLevelingUtil.java
@@ -64,7 +64,7 @@ public class MobLevelingUtil {
         int level,
         Store<EntityStore> store
     ) {
-        if (npc.getReference() == null)
+        if (npc.getReference() == null || !npc.getReference().isValid())
             return false;
 
         store.getExternalData().getWorld().execute(() -> {


### PR DESCRIPTION
## 📌 Description
This is a one-liner PR that fixes this error that appears semi-frequently on my server:
(This can happen with varied stack traces, sometimes it's Hytale's vanilla logic removing an entity, sometimes it's third party mods)
```
[World|default] Failed to run task!
java.lang.IllegalStateException: Invalid entity reference!
        at com.hypixel.hytale.component.Ref.validate(Ref.java:59)
        at com.hypixel.hytale.component.Store.__internal_getComponent(Store.java:1222)
        at com.hypixel.hytale.component.Store.getComponent(Store.java:1216)
        at ThirdPartyPlugin//com.azuredoom.levelingcore.utils.MobLevelingUtil.lambda$applyMobScaling$0(MobLevelingUtil.java:72)
        at com.hypixel.hytale.server.core.universe.world.World.consumeTaskQueue(World.java:904)
        at com.hypixel.hytale.server.core.universe.world.World.tick(World.java:403)
        at com.hypixel.hytale.server.core.util.thread.TickingThread.run(TickingThread.java:89)
        at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.Throwable
        at com.hypixel.hytale.component.CommandBuffer.removeEntity(CommandBuffer.java:291)
        at com.hypixel.hytale.server.npc.systems.NPCPreTickSystem.steppedTick(NPCPreTickSystem.java:128)
        at com.hypixel.hytale.server.npc.systems.SteppableTickingSystem.tick(SteppableTickingSystem.java:53)
        at com.hypixel.hytale.component.system.tick.EntityTickingSystem.doTick(EntityTickingSystem.java:92)
        at com.hypixel.hytale.component.system.tick.EntityTickingSystem.tick(EntityTickingSystem.java:36)
        at com.hypixel.hytale.component.Store.tick(Store.java:1974)
        at com.hypixel.hytale.component.system.tick.ArchetypeTickingSystem.tick(ArchetypeTickingSystem.java:36)
        at com.hypixel.hytale.component.Store.tickInternal(Store.java:1930)
        at com.hypixel.hytale.component.Store.tick(Store.java:1900)
        at com.hypixel.hytale.server.core.universe.world.World.tick(World.java:406)
        ... 2 more
```

---

## 🧪 Type of Change

Please check the types of changes your PR introduces:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Tests added / updated

---

## 👩‍💻 Implementation Details

Before modifying the entity data in `MobLevelingUtil#applyMobScaling`, it makes sure that the entity reference is still valid.

### 🛠 Changes

- Added a validity check in `MobLevelingUtil#applyMobScaling`:
```patch
- if (npc.getReference() == null)
+ if (npc.getReference() == null || !npc.getReference().isValid())
```

---

## ✅ Checklist

Go over all the following items and check them before submitting your PR:

- [x] My code follows the project’s **code style** (simply run `spotlessApply` to apply formatting)
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings